### PR TITLE
Version pin nan to 1.* to fix breaking changes in nan

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mcrypt",
-    "version": "0.0.14",
+    "version": "0.0.15",
     "description": "MCrypt bindings",
     "keywords": ["mcrypt", "crypto"],
     "homepage": "https://github.com/tugrul/node-mcrypt",
@@ -21,7 +21,7 @@
         "node" : ">=0.8.0"
     },
     "dependencies": {
-        "nan": "*"
+        "nan": "^1.9.0"
     },
     "devDependencies": {
         "node-gyp" : "*"


### PR DESCRIPTION
nan pushed new changes versioned as 2.0.0 and 1.9.0. 1.9.0 did not contain the breaking changes. The version pinning was inadequate to catch this. Work is needed to build mcrypt with nan 2, but this keeps from breaking builds right now.