### PR TITLE
Add support for travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: node_js
+node_js:
+  - '5'
+  - '4'
+  - '3'
+  - '2'
+  - '0.12'
+  - '0.8'
+sudo: false
+script: npm install . && npm test

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# node-mcrypt
+# node-mcrypt [![Build Status](https://travis-ci.org/tugrul/node-mcrypt.svg)](https://travis-ci.org/tugrul/node-mcrypt)
 
 MCrypt bindings for Node.js
 

--- a/package.json
+++ b/package.json
@@ -1,30 +1,35 @@
 {
-    "name": "mcrypt",
-    "version": "0.1.4",
-    "description": "MCrypt bindings",
-    "keywords": ["mcrypt", "crypto"],
-    "homepage": "https://github.com/tugrul/node-mcrypt",
-    "author": "Tuğrul Topuz <tugrultopuz@gmail.com>",
-    "bugs": {
-        "url": "https://github.com/tugrul/node-mcrypt/issues"
-    },
-    "license": "MIT",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/tugrul/node-mcrypt.git"
-    },
-    "scripts": {
-        "install": "node-gyp rebuild --release",
-        "preuninstall": "rm -rf build/*"
-    },
-    "engines": {
-        "node" : ">=0.8.0"
-    },
-    "dependencies": {
-        "nan": "^2.1.0"
-    },
-    "devDependencies": {
-        "node-gyp" : "*"
-    },
-    "main": "./build/Release/mcrypt"
+  "name": "mcrypt",
+  "version": "0.1.4",
+  "description": "MCrypt bindings",
+  "keywords": [
+    "mcrypt",
+    "crypto"
+  ],
+  "homepage": "https://github.com/tugrul/node-mcrypt",
+  "author": "Tuğrul Topuz <tugrultopuz@gmail.com>",
+  "bugs": {
+    "url": "https://github.com/tugrul/node-mcrypt/issues"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tugrul/node-mcrypt.git"
+  },
+  "scripts": {
+    "test": "./node_modules/mocha/bin/mocha test/test.js",
+    "install": "node-gyp rebuild --release",
+    "preuninstall": "rm -rf build/*"
+  },
+  "engines": {
+    "node": ">=0.8.0"
+  },
+  "dependencies": {
+    "nan": "^2.1.0"
+  },
+  "devDependencies": {
+    "mocha": "^2.3.3",
+    "node-gyp": "*"
+  },
+  "main": "./build/Release/mcrypt"
 }


### PR DESCRIPTION
You have to link your github account with https://travis-ci.org/ and add the node-mcrypt repo.

This allow tests with the different nodejs versions.

Actually, they are 3 errors (tested with nodejs 4.2):
```
  3 failing

  1) MCrypt constructor should throw exception without parameters:
     Error: MCrypt module could not open
      at Error (native)
      at test/test.js:51:17
      at Function._throws (assert.js:297:5)
      at Function.assert.throws (assert.js:323:11)
      at Context.<anonymous> (test/test.js:50:20)

  2) MCrypt constructor should throw exception with wrong parameters:
     Error: MCrypt module could not open
language: node_js
      at Error (native)
      at test/test.js:63:17
      at Function._throws (assert.js:297:5)
      at Function.assert.throws (assert.js:323:11)
      at Context.<anonymous> (test/test.js:62:20)

  3) MCrypt MCrypt instance (DES-ECB) open selfTest should return true:

      AssertionError: return value is not true
      + expected - actual

      -false
      +true
      
      at Context.<anonymous> (test/test.js:130:21)
```