### PR TITLE
Travis: upgrade g++ to 4.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,10 @@ node_js:
   - '2'
   - '0.12'
   - '0.8'
-sudo: false
+sudo: true
+before_install:
+  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq g++-4.8
+  - export CXX="g++-4.8" CC="gcc-4.8"
 script: npm install . && npm test


### PR DESCRIPTION
Try to fix:
```
../node_modules/nan/nan.h:41:3: error: #error This version of node/NAN/v8 requires a C++11 compiler
```