### PR TITLE
Add index.js to avoid flow module node found error.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+'use strict';
+
+require('./build/Release/mcrypt');


### PR DESCRIPTION
When I'm using facebook flow 
```
src/Common/Domain/AesEncryptionService.js:4
  4: var MCrypt = require('mcrypt').MCrypt;
                  ^^^^^^^^^^^^^^^^^ mcrypt. Required module not found


Found 1 error
```

<img width="389" alt="capture d ecran 2016-01-25 a 11 52 01" src="https://cloud.githubusercontent.com/assets/54712/12549012/93fe2426-c35a-11e5-9966-ec8782bc8996.png">
