### PR TITLE
Bump nan dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "node": ">=0.10.16"
   },
   "dependencies": {
-    "nan": "^2.1.0"
+    "nan": "^2.3.3"
   },
   "devDependencies": {
     "mocha": "^2.3.3",


### PR DESCRIPTION
Depend on newer nan version.

Specifically, bumps nan past this bugfix: https://github.com/nodejs/nan/blob/master/CHANGELOG.md#231-apr-27-2016

Should fix #54, which was caused by (in my case) another package pinning to 2.2.1, which satisfied ^2.1.0