### PR TITLE
Use node `path` as path resolver for webpack

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
 'use strict';
+const path = require('path');
 
-module.exports = require('./build/Release/mcrypt');
+module.exports = require(path.join(__dirname, 'build/Release/mcrypt'));


### PR DESCRIPTION
I am having this issue when using webpack to bundle my file and this is the error being thrown:
```
ERROR in ./node_modules/mcrypt/index.js
Module not found: Error: Can't resolve './build/Release/mcrypt' in '.......\node_modules\mcrypt'
```

I am able to resolve this by using `path` package from nodejs and I am going to propose the changes here. Hopefully you can review and let me know if this is good?