### PR TITLE
fix(package): bump nan version to ^2.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "bindings": "^1.3.0",
-    "nan": "^2.3.3"
+    "nan": "^2.8.0"
   },
   "devDependencies": {
     "mocha": "^2.3.3",


### PR DESCRIPTION
  mcrypt requires an version of nan gte 2.8
  if nan is required by an other package in a version strictly below 2.8,
  npm will resolve dependencies with the lowest common version

(nan-version-conflict)

Sorry @tugrul but I have a nan version conflicts between several dependencies and I had to bump nan version in your package.